### PR TITLE
avoid the zealous replacing of ampersands

### DIFF
--- a/src/clustaar/schemas/processors.py
+++ b/src/clustaar/schemas/processors.py
@@ -3,8 +3,11 @@ import unicodedata
 
 
 def html_sanitize(value):
-    """Sanitize HTML in value to avoid malicious usage"""
-    return bleach.clean(value) if value else value
+    """
+    Sanitize HTML in value to avoid malicious usage.
+    Bleach is a bit excessive with the ampersands, and we prefer to keep it as they were.
+    """
+    return bleach.clean(value).replace("&amp;", "&") if value else value
 
 
 def unicode_normalize(value):

--- a/src/clustaar/schemas/processors.py
+++ b/src/clustaar/schemas/processors.py
@@ -1,13 +1,15 @@
 import bleach
 import unicodedata
 
+SANE_TAGS = bleach.sanitizer.ALLOWED_TAGS + ["br"]
+
 
 def html_sanitize(value):
     """
     Sanitize HTML in value to avoid malicious usage.
     Bleach is a bit excessive with the ampersands, and we prefer to keep it as they were.
     """
-    return bleach.clean(value).replace("&amp;", "&") if value else value
+    return bleach.clean(value, tags=SANE_TAGS).replace("&amp;", "&") if value else value
 
 
 def unicode_normalize(value):

--- a/tests/schemas/v1/test_send_text_action.py
+++ b/tests/schemas/v1/test_send_text_action.py
@@ -24,6 +24,11 @@ def data2():
 
 
 @pytest.fixture
+def ampersand_data():
+    return {"type": "send_text_action", "alternatives": ["Hi", "Hello & How Are You?"]}
+
+
+@pytest.fixture
 def malicious_data():
     return {"type": "send_text_action", "alternatives": ["<script>void();</script>Hi", "Hello"]}
 
@@ -47,6 +52,10 @@ class TestLoad:
     def test_fail_load_text(self, data, mapper):
         action = mapper.load(data, SEND_TEXT_ACTION)
         assert action.text is None
+
+    def test_preserve_ampersand(self, ampersand_data, mapper):
+        action = mapper.load(ampersand_data, SEND_TEXT_ACTION)
+        assert action.alternatives == ["Hi", "Hello & How Are You?"]
 
     def test_returns_an_action_malicious(self, malicious_data, mapper):
         send_text = mapper.load(malicious_data, SEND_TEXT_ACTION)

--- a/tests/schemas/v1/test_send_text_action.py
+++ b/tests/schemas/v1/test_send_text_action.py
@@ -29,6 +29,11 @@ def ampersand_data():
 
 
 @pytest.fixture
+def br_data():
+    return {"type": "send_text_action", "alternatives": ["Hi<br>", "Hello & <br />How Are You?"]}
+
+
+@pytest.fixture
 def malicious_data():
     return {"type": "send_text_action", "alternatives": ["<script>void();</script>Hi", "Hello"]}
 
@@ -56,6 +61,10 @@ class TestLoad:
     def test_preserve_ampersand(self, ampersand_data, mapper):
         action = mapper.load(ampersand_data, SEND_TEXT_ACTION)
         assert action.alternatives == ["Hi", "Hello & How Are You?"]
+
+    def test_preserve_br(self, br_data, mapper):
+        action = mapper.load(br_data, SEND_TEXT_ACTION)
+        assert action.alternatives == ["Hi<br>", "Hello & <br>How Are You?"]
 
     def test_returns_an_action_malicious(self, malicious_data, mapper):
         send_text = mapper.load(malicious_data, SEND_TEXT_ACTION)

--- a/tests/schemas/v1/test_send_text_action.py
+++ b/tests/schemas/v1/test_send_text_action.py
@@ -34,6 +34,14 @@ def br_data():
 
 
 @pytest.fixture
+def re_data():
+    return {
+        "type": "send_text_action",
+        "alternatives": ["Hi(?P\d{5})", "Hello & (?P\d{5})How Are You?"],
+    }
+
+
+@pytest.fixture
 def malicious_data():
     return {"type": "send_text_action", "alternatives": ["<script>void();</script>Hi", "Hello"]}
 
@@ -65,6 +73,10 @@ class TestLoad:
     def test_preserve_br(self, br_data, mapper):
         action = mapper.load(br_data, SEND_TEXT_ACTION)
         assert action.alternatives == ["Hi<br>", "Hello & <br>How Are You?"]
+
+    def test_preserve_regex(self, re_data, mapper):
+        action = mapper.load(re_data, SEND_TEXT_ACTION)
+        assert action.alternatives == ["Hi(?P\d{5})", "Hello & (?P\d{5})How Are You?"]
 
     def test_returns_an_action_malicious(self, malicious_data, mapper):
         send_text = mapper.load(malicious_data, SEND_TEXT_ACTION)


### PR DESCRIPTION
as discussed.
Vu aussi avec Paul : ils utilisent parfois les `&` dans les textes, donc faudrait a minima qu'ils s'affichent joliment et pas en entité html.